### PR TITLE
feat(orbit): add new rule for using TextNode

### DIFF
--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -19,10 +19,12 @@ import { nitroUseStringForNonDynamicTranslationKeys } from './nitro/nitro-use-st
 import { selectorNaming } from './frontend/selector-naming'
 import { preferNitroTranslateFunction } from './nitro/prefer-nitro-translate-function'
 import { correctTranslationUsage } from './nitro/correct-translation-usage'
+import { preferNitroTextNodeComponent } from './orbit/prefer-nitro-textnode-component'
 
 export const rules = {
   'orbit-text-component-name': orbitTextComponentName,
   'prefer-nitro-text-component': preferNitroTextComponent,
+  'prefer-nitro-textnode-component': preferNitroTextNodeComponent,
   'prefer-nitro-translate-component': preferNitroTranslateComponent,
   'no-tkey-nitro-translate-component': noTkeyNitroTranslateComponent,
   'nitro-use-string-for-non-dynamic-translation-keys': nitroUseStringForNonDynamicTranslationKeys,

--- a/src/rules/nitro/__tests__/correct-translation-usage.spec.js
+++ b/src/rules/nitro/__tests__/correct-translation-usage.spec.js
@@ -1,5 +1,5 @@
 import { ruleTester } from '../../../common/ruleTester'
-const { rules } = require('../../index')
+import { rules } from '../../index'
 
 const correctTranslationUsage = rules['correct-translation-usage']
 

--- a/src/rules/nitro/correct-translation-usage.js
+++ b/src/rules/nitro/correct-translation-usage.js
@@ -4,7 +4,7 @@
 
 import * as R from 'ramda'
 
-const realTranslations = require('@kiwicom/translations/lib/en-GB.json')
+import realTranslations from '@kiwicom/translations/lib/en-GB.json'
 
 const parseOptions = context => {
   const { options } = context

--- a/src/rules/orbit/__tests__/prefer-nitro-textnode-component.spec.js
+++ b/src/rules/orbit/__tests__/prefer-nitro-textnode-component.spec.js
@@ -1,0 +1,48 @@
+import { ruleTester } from '../../../common/ruleTester'
+import { preferNitroTextNodeComponent } from '../prefer-nitro-textnode-component'
+
+describe('Prefer nitro text', function() {
+  ruleTester.run('prefer-nitro-text-component', preferNitroTextNodeComponent, {
+    valid: [
+      '<TextNode t="translation.key" />',
+      '<Button kind="primary"><TranslateNode t="translation.ket" /></Button>'
+    ],
+    invalid: [
+      {
+        code: `<OrbitText><TranslateNode t="translation.key" /></OrbitText>`,
+        errors: [
+          {
+            messageId: 'preferNitroTextNode'
+          }
+        ]
+      },
+      {
+        code: `
+      <OrbitText>
+          <TranslateNode t="translation.key" />
+      </OrbitText>`,
+        errors: [
+          {
+            messageId: 'preferNitroTextNode'
+          }
+        ]
+      },
+      {
+        code: `
+     <span className="spStatus _closed">
+          <OrbitText>
+            <TranslateNode tKey="common.booking_state_closed" />
+          </OrbitText>
+        </span>
+`,
+        errors: [
+          {
+            messageId: 'preferNitroTextNode'
+          }
+        ]
+      }
+    ],
+    output:
+      'Prefer TextNode imported from Nitro library import TextNode from "@kiwicom/nitro/lib/components/TextNode"'
+  })
+})

--- a/src/rules/orbit/prefer-nitro-textnode-component.js
+++ b/src/rules/orbit/prefer-nitro-textnode-component.js
@@ -1,0 +1,45 @@
+// text-component-name-push
+import * as R from 'ramda'
+
+const getOpeningElementName = R.path(['openingElement', 'name', 'name'])
+const getElementName = R.path(['name', 'name'])
+
+export const preferNitroTextNodeComponent = {
+  meta: {
+    messages: {
+      preferNitroTextNode: `Prefer TextNode imported from Nitro library
+      
+      import TextNode from "@kiwicom/nitro/lib/components/TextNode"'
+      `
+    }
+  },
+  create: context => {
+    return {
+      JSXOpeningElement(node) {
+        const elementName = getElementName(node)
+        if (elementName === 'OrbitText') {
+          const parent = node.parent
+
+          const JSXElements = parent.children.filter(
+            child => child.type === 'JSXElement'
+          )
+          const translateElement = JSXElements.find(
+            child => getOpeningElementName(child) === 'TranslateNode'
+          )
+
+          const closingElement = parent.closingElement
+
+          if (translateElement && JSXElements.length === 1) {
+            return context.report({
+              loc: {
+                start: node.name.loc.start,
+                end: closingElement.name.loc.end
+              },
+              messageId: 'preferNitroTextNode'
+            })
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Following code is now invalid.

```js
 <OrbitText>
          <TranslateNode t="translation.key" />
  </OrbitText>
```