### PR TITLE
feat(nitro): add allowed-tag-names-in-translation-components

### DIFF
--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -20,6 +20,7 @@ import { selectorNaming } from './frontend/selector-naming'
 import { preferNitroTranslateFunction } from './nitro/prefer-nitro-translate-function'
 import { correctTranslationUsage } from './nitro/correct-translation-usage'
 import { preferNitroTextNodeComponent } from './orbit/prefer-nitro-textnode-component'
+import { allowedTagNamesInTranslationComponents } from './nitro/allowed-tag-names-in-translation-components'
 
 export const rules = {
   'orbit-text-component-name': orbitTextComponentName,
@@ -30,5 +31,6 @@ export const rules = {
   'nitro-use-string-for-non-dynamic-translation-keys': nitroUseStringForNonDynamicTranslationKeys,
   'selector-naming': selectorNaming,
   'prefer-nitro-translate-function': preferNitroTranslateFunction,
+  'allowed-tag-names-in-translation-components': allowedTagNamesInTranslationComponents,
   'correct-translation-usage': correctTranslationUsage
 }

--- a/src/rules/nitro/__tests__/allowed-tag-names-in-translation-components.spec.js
+++ b/src/rules/nitro/__tests__/allowed-tag-names-in-translation-components.spec.js
@@ -1,0 +1,90 @@
+import { ruleTester } from '../../../common/ruleTester'
+import { allowedTagNamesInTranslationComponents } from '../allowed-tag-names-in-translation-components'
+
+describe('Allowed tag names in translation components', function() {
+  ruleTester.run(
+    'allowed-tag-names-in-translation-components',
+    allowedTagNamesInTranslationComponents,
+    {
+      valid: [
+        `<Translate t="tKey" />`,
+        `<TranslateNode t="tKey" />`,
+        `<TranslateNode t="tKey" tags={{ ref: ref => <p>{ref}</p>}} />`,
+        `<TranslateNode t="tKey" tags={{ ref1: ref => <p>{ref}</p>}} />`,
+        `<TranslateNode t="tKey" tags={{ ref2: ref => <p>{ref}</p>, ref3: ref => <p>{ref}</p>, ref4: ref => <p>{ref}</p>, ref5: ref => <p>{ref}</p>}} />`,
+        `<TextNode t="tKey" />`,
+        `<TextNode t="tKey" tags={{ ref: ref => <p>{ref}</p>}} />`,
+        `<TextNode t="tKey" tags={{ ref1: ref => <p>{ref}</p>}} />`,
+        `<TextNode t="tKey" tags={{ ref2: ref => <p>{ref}</p>, ref3: ref => <p>{ref}</p>, ref4: ref => <p>{ref}</p>, ref5: ref => <p>{ref}</p>}} />`
+      ],
+      invalid: [
+        {
+          code: `<TranslateNode t="tKey" tags={{ privacy: ref => <a>{ref}</a> }} />`,
+          errors: [
+            {
+              line: 1,
+              endLine: 1,
+              column: 33,
+              endColumn: 40,
+              message:
+                'Tag name privacy is not allowed. Allowed tag names: ref, ref1, ref2, ref3, ref4, ref5'
+            }
+          ]
+        },
+        {
+          code: `
+          <TranslateNode
+            t="tKey"
+            tags={{
+              privacy: ref => <a>{ref}</a>,
+              terms: ref => <a>{ref}</a>
+            }}
+          />`,
+          errors: [
+            {
+              line: 5,
+              endLine: 5,
+              column: 15,
+              endColumn: 22,
+              message:
+                'Tag name privacy is not allowed. Allowed tag names: ref, ref1, ref2, ref3, ref4, ref5'
+            },
+            {
+              line: 6,
+              endLine: 6,
+              column: 15,
+              endColumn: 20,
+              message:
+                'Tag name terms is not allowed. Allowed tag names: ref, ref1, ref2, ref3, ref4, ref5'
+            }
+          ]
+        },
+        {
+          code: `<TranslateNode t="tKey" tags={{ ref: ref => <p>{ref}</p>, privacy: ref => <a>{ref}</a> }} />`,
+          errors: [
+            'Tag name privacy is not allowed. Allowed tag names: ref, ref1, ref2, ref3, ref4, ref5'
+          ]
+        },
+        {
+          code: `<TextNode t="tKey" tags={{ privacy: ref => <a>{ref}</a> }} />`,
+          errors: [
+            'Tag name privacy is not allowed. Allowed tag names: ref, ref1, ref2, ref3, ref4, ref5'
+          ]
+        },
+        {
+          code: `<TextNode t="tKey" tags={{ privacy: ref => <a>{ref}</a>, terms: ref => <a>{ref}</a> }} />`,
+          errors: [
+            'Tag name privacy is not allowed. Allowed tag names: ref, ref1, ref2, ref3, ref4, ref5',
+            'Tag name terms is not allowed. Allowed tag names: ref, ref1, ref2, ref3, ref4, ref5'
+          ]
+        },
+        {
+          code: `<TextNode t="tKey" tags={{ ref: ref => <p>{ref}</p>, privacy: ref => <a>{ref}</a> }} />`,
+          errors: [
+            'Tag name privacy is not allowed. Allowed tag names: ref, ref1, ref2, ref3, ref4, ref5'
+          ]
+        }
+      ]
+    }
+  )
+})

--- a/src/rules/nitro/allowed-tag-names-in-translation-components.js
+++ b/src/rules/nitro/allowed-tag-names-in-translation-components.js
@@ -1,0 +1,50 @@
+import * as R from 'ramda'
+
+const ALLOWED_TAG_NAMES = ['ref', 'ref1', 'ref2', 'ref3', 'ref4', 'ref5']
+const COMPONENT_WITH_PROP_TAGS = ['TranslateNode', 'TextNode']
+
+const getElementName = R.path(['name', 'name'])
+const getComponentAttributes = R.path(['attributes'])
+const getAttributeProperties = R.path(['value', 'expression', 'properties'])
+
+export const allowedTagNamesInTranslationComponents = {
+  meta: {
+    messages: {
+      invalidTagName: `Tag name {{ invalidTagName }} is not allowed. Allowed tag names: ${ALLOWED_TAG_NAMES.join(
+        ', '
+      )}`
+    }
+  },
+  create: context => {
+    return {
+      JSXOpeningElement(node) {
+        const name = getElementName(node)
+
+        if (COMPONENT_WITH_PROP_TAGS.includes(name)) {
+          const attributes = getComponentAttributes(node)
+
+          const nodeWithTagsAttribute = R.find(
+            R.pathEq(['name', 'name'], 'tags'),
+            attributes
+          )
+
+          if (nodeWithTagsAttribute) {
+            const tagNameNodes = getAttributeProperties(
+              nodeWithTagsAttribute
+            ).map(property => property.key)
+
+            tagNameNodes.forEach(tagNameNode => {
+              if (!ALLOWED_TAG_NAMES.includes(tagNameNode.name)) {
+                return context.report({
+                  loc: tagNameNode.loc,
+                  messageId: 'invalidTagName',
+                  data: { invalidTagName: tagNameNode.name }
+                })
+              }
+            })
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Custom tag names for TranslateNode and TextNode are breaking LOC's tools. It was agreed to only use the following tag names: `ref`, `ref1`, `ref2`, `ref3`, `ref4`, `ref5`. This ESLint rule will return an error if any other tag name is used.