### PR TITLE
feat(orbit): add prefer-nitro-button-component rule

### DIFF
--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -21,12 +21,14 @@ import { preferNitroTranslateFunction } from './nitro/prefer-nitro-translate-fun
 import { correctTranslationUsage } from './nitro/correct-translation-usage'
 import { preferNitroTextNodeComponent } from './orbit/prefer-nitro-textnode-component'
 import { allowedTagNamesInTranslationComponents } from './nitro/allowed-tag-names-in-translation-components'
+import { preferNitroButtonComponent } from './orbit/prefer-nitro-button-component'
 
 export const rules = {
   'orbit-text-component-name': orbitTextComponentName,
   'prefer-nitro-text-component': preferNitroTextComponent,
   'prefer-nitro-textnode-component': preferNitroTextNodeComponent,
   'prefer-nitro-translate-component': preferNitroTranslateComponent,
+  'prefer-nitro-button-component': preferNitroButtonComponent,
   'no-tkey-nitro-translate-component': noTkeyNitroTranslateComponent,
   'nitro-use-string-for-non-dynamic-translation-keys': nitroUseStringForNonDynamicTranslationKeys,
   'selector-naming': selectorNaming,

--- a/src/rules/orbit/__tests__/prefer-nitro-button-component.spec.js
+++ b/src/rules/orbit/__tests__/prefer-nitro-button-component.spec.js
@@ -1,0 +1,35 @@
+import { ruleTester } from '../../../common/ruleTester'
+import { preferNitroButtonComponent } from '../prefer-nitro-button-component'
+
+describe('Prefer nitro button', function() {
+  ruleTester.run('prefer-nitro-button-component', preferNitroButtonComponent, {
+    valid: [
+      '<Button t="translation.key" />',
+      '<Button t="translation.key" values={{ companyName: "Kiwi.com "}} />',
+      '<Button>{condition ? <Translate t="next" /> : <Translate t="pay" values={{ price: "12 EUR" }} />}</Button>',
+      '<Button>{customLabel || <Translate t="translation.key" />}</Button>',
+      '<Button>{someFunctionToRenderLabel(state)}</Button>',
+      '<Button type="secondary">Close</Button>',
+      '<Button><TranslateNode t="translation.key" /></Button>',
+      '<ButtonLink><Translate t="translation.key" /></ButtonLink>'
+    ],
+    invalid: [
+      {
+        code: `<Button><Translate t="translation.key" /></Button>`,
+        errors: [{ messageId: 'preferNitroButton' }]
+      },
+      {
+        code: `<Button><Translate t="translation.key" values={{ companyName: "Kiwi.com "}} /></Button>`,
+        errors: [{ messageId: 'preferNitroButton' }]
+      },
+      {
+        code: `<Button><Translate t={someFunctionToRenderLabel(state)} /></Button>`,
+        errors: [{ messageId: 'preferNitroButton' }]
+      },
+      {
+        code: `<Button><Translate tKey="translation.key" /></Button>`,
+        errors: [{ messageId: 'preferNitroButton' }]
+      }
+    ]
+  })
+})

--- a/src/rules/orbit/prefer-nitro-button-component.js
+++ b/src/rules/orbit/prefer-nitro-button-component.js
@@ -1,0 +1,44 @@
+import * as R from 'ramda'
+
+const getOpeningElementName = R.path(['openingElement', 'name', 'name'])
+const getElementName = R.path(['name', 'name'])
+const getProps = R.map(R.path(['name', 'name']))
+
+export const preferNitroButtonComponent = {
+  meta: {
+    messages: {
+      preferNitroButton: `Translate is wrapped in Orbit's Button component. Prefer using Nitro's Button which does the same. import Button from "@kiwicom/nitro/lib/components/Button"`
+    }
+  },
+  create: context => {
+    return {
+      JSXOpeningElement(node) {
+        const elementName = getElementName(node)
+
+        if (
+          elementName === 'Button' &&
+          !getProps(node.attributes).includes('t')
+        ) {
+          const { parent } = node
+
+          const JSXElements = parent.children.filter(
+            child => child.type === 'JSXElement'
+          )
+          const translateElement = JSXElements.find(
+            child => getOpeningElementName(child) === 'Translate'
+          )
+
+          if (translateElement && JSXElements.length === 1) {
+            return context.report({
+              loc: {
+                start: node.name.loc.start,
+                end: parent.closingElement.name.loc.end
+              },
+              messageId: 'preferNitroButton'
+            })
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Rule to suggest using Nitro's Button component instead of having Nitro's Translate component inside the Orbit's Button component.